### PR TITLE
Move to openSUSE base images

### DIFF
--- a/csm-extensions/services/dev-mysql/Dockerfile-setup
+++ b/csm-extensions/services/dev-mysql/Dockerfile-setup
@@ -1,19 +1,12 @@
+ARG base_image=opensuse:latest
+
 FROM cf-usb-sidecar-buildbase:latest as builder
 
-ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update
-RUN apt-get install -y unzip
-RUN mkdir /out
-RUN wget -O cf.tgz 'https://cli.run.pivotal.io/stable?release=linux64-binary'
-RUN tar xzf cf.tgz -C /out cf
-RUN wget -O cf-plugin-usb.zip https://github.com/SUSE/cf-usb-plugin/releases/download/0.0.1/cf-plugin-usb-linux-amd64.zip
-RUN unzip cf-plugin-usb.zip
-RUN mv cf-plugin-usb /out
 COPY chart/scf-connector.sh /out/
 COPY chart/authorize_ca.sh  /out/
-RUN chmod +x /out/cf /out/cf-plugin-usb /out/scf-connector.sh
+RUN chmod +x /out/scf-connector.sh
 
-FROM cf-usb-sidecar-buildbase:latest
+FROM ${base_image}
 COPY --from=builder /out/ /usr/local/bin/
 WORKDIR /
 ENTRYPOINT /bin/bash /usr/local/bin/scf-connector.sh

--- a/csm-extensions/services/dev-postgres/Dockerfile-setup
+++ b/csm-extensions/services/dev-postgres/Dockerfile-setup
@@ -1,19 +1,12 @@
+ARG base_image=opensuse:latest
+
 FROM cf-usb-sidecar-buildbase:latest as builder
 
-ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update
-RUN apt-get install -y unzip
-RUN mkdir /out
-RUN wget -O cf.tgz 'https://cli.run.pivotal.io/stable?release=linux64-binary'
-RUN tar xzf cf.tgz -C /out cf
-RUN wget -O cf-plugin-usb.zip https://github.com/SUSE/cf-usb-plugin/releases/download/0.0.1/cf-plugin-usb-linux-amd64.zip
-RUN unzip cf-plugin-usb.zip
-RUN mv cf-plugin-usb /out
 COPY chart/scf-connector.sh /out/
 COPY chart/authorize_ca.sh  /out/
-RUN chmod +x /out/cf /out/cf-plugin-usb /out/scf-connector.sh
+RUN chmod +x /out/scf-connector.sh
 
-FROM cf-usb-sidecar-buildbase:latest
+FROM ${base_image}
 COPY --from=builder /out/ /usr/local/bin/
 WORKDIR /
 ENTRYPOINT /bin/bash /usr/local/bin/scf-connector.sh

--- a/scripts/dev-extensions/build-docker-image.sh
+++ b/scripts/dev-extensions/build-docker-image.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 set -o errexit
-docker build -t ${SIDECAR_EXTENSION_IMAGE_NAME}:${SIDECAR_EXTENSION_IMAGE_TAG} --rm -f Dockerfile       .
+docker build -t ${SIDECAR_EXTENSION_IMAGE_NAME}:${SIDECAR_EXTENSION_IMAGE_TAG} --rm ${SIDECAR_PARENT_IMAGE:+--build-arg base_image=${SIDECAR_PARENT_IMAGE}} -f Dockerfile       .
 if test -f Dockerfile-setup ; then
-    docker build -t ${SIDECAR_SETUP_IMAGE_NAME}:${SIDECAR_SETUP_IMAGE_TAG}     --rm -f Dockerfile-setup .
+    docker build -t ${SIDECAR_SETUP_IMAGE_NAME}:${SIDECAR_SETUP_IMAGE_TAG}     --rm ${SIDECAR_PARENT_IMAGE:+--build-arg base_image=${SIDECAR_PARENT_IMAGE}} -f Dockerfile-setup .
 fi

--- a/scripts/docker/Dockerfile-build
+++ b/scripts/docker/Dockerfile-build
@@ -1,26 +1,27 @@
-FROM golang:1.8.4
+ARG base_image=opensuse:latest
 
-ENV GOPATH /go
-ENV GOBIN /go/bin
-ENV DEBIAN_FRONTEND=noninteractive
+FROM ${base_image}
 
-RUN apt-get update
-RUN apt-get install -y \
+RUN zypper --non-interactive addrepo --check --gpgcheck obs://Cloud:Tools Cloud:Tools
+RUN zypper --non-interactive addrepo --check --gpgcheck obs://devel:languages:go devel:languages:go
+RUN zypper --non-interactive --gpg-auto-import-keys refresh
+RUN zypper --non-interactive install \
+    cf-cli \
     git \
-    bash \
+    go \
     make \
-    gcc \
-    mercurial \
-    build-essential \
-    unzip
+    unzip \
+    wget \
+    ${NULL}
 
 RUN mkdir /out
-RUN wget -O cf.tgz 'https://cli.run.pivotal.io/stable?release=linux64-binary'
-RUN tar xzf cf.tgz -C /out cf
+
+RUN cp /usr/bin/cf /out
+
 RUN wget -O cf-plugin-usb.zip https://github.com/SUSE/cf-usb-plugin/releases/download/0.0.1/cf-plugin-usb-linux-amd64.zip
 RUN unzip cf-plugin-usb.zip
 RUN mv cf-plugin-usb /out
-RUN chmod +x /out/cf /out/cf-plugin-usb
+RUN chmod +x /out/cf-plugin-usb
 
 COPY . /go/src/github.com/SUSE/cf-usb-sidecar
 

--- a/scripts/docker/Dockerfile-build
+++ b/scripts/docker/Dockerfile-build
@@ -2,23 +2,30 @@ FROM golang:1.8.4
 
 ENV GOPATH /go
 ENV GOBIN /go/bin
+ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+RUN apt-get update
+RUN apt-get install -y \
     git \
     bash \
     make \
     gcc \
     mercurial \
     build-essential \
-    && apt-get autoremove -y \
-    && apt-get clean -y \
-    && rm -rf /var/lib/apt/lists/*
+    unzip
+
+RUN mkdir /out
+RUN wget -O cf.tgz 'https://cli.run.pivotal.io/stable?release=linux64-binary'
+RUN tar xzf cf.tgz -C /out cf
+RUN wget -O cf-plugin-usb.zip https://github.com/SUSE/cf-usb-plugin/releases/download/0.0.1/cf-plugin-usb-linux-amd64.zip
+RUN unzip cf-plugin-usb.zip
+RUN mv cf-plugin-usb /out
+RUN chmod +x /out/cf /out/cf-plugin-usb
 
 COPY . /go/src/github.com/SUSE/cf-usb-sidecar
 
-RUN cd /go/src/github.com/SUSE/cf-usb-sidecar \
-    && make tools \
-    && cd / \
-    && rm -rf /go/src/github.com/hpcloud
+WORKDIR /go/src/github.com/SUSE/cf-usb-sidecar
+
+RUN make tools
 
 ENTRYPOINT echo `hostname`

--- a/scripts/docker/generate-build-image.sh
+++ b/scripts/docker/generate-build-image.sh
@@ -39,4 +39,5 @@ printf "%b==> Building ${SIDECAR_BUILD_BASE_IMAGE_NAME}:${SIDECAR_BUILD_BASE_IMA
 docker build \
     --tag "${SIDECAR_BUILD_BASE_IMAGE_NAME}:${SIDECAR_BUILD_BASE_IMAGE_TAG}" \
     --rm \
+	${SIDECAR_BUILD_BASE_PARENT_IMAGE:+--build-arg base_image=${SIDECAR_BUILD_BASE_PARENT_IMAGE}} \
     --file "${script_dir}/Dockerfile-build" .

--- a/scripts/docker/release/Dockerfile-release
+++ b/scripts/docker/release/Dockerfile-release
@@ -1,3 +1,5 @@
+ARG base_image=opensuse:latest
+
 FROM cf-usb-sidecar-buildbase:latest as builder
 
 ENV GOPATH /go
@@ -5,12 +7,10 @@ ENV GOBIN /go/bin
 
 COPY . /go/src/github.com/SUSE/cf-usb-sidecar
 
-RUN go version
-
 WORKDIR /go/src/github.com/SUSE/cf-usb-sidecar
 RUN make clean-all build
 
-FROM opensuse:42.3
+FROM ${base_image}
 
 RUN mkdir -p /catalog-service-manager/bin \
     /catalog-service-manager/setup/startup \
@@ -24,5 +24,3 @@ RUN mkdir -p /catalog-service-manager/bin \
 
 COPY --from=builder /go/bin/catalog-service-manager /catalog-service-manager/bin/
 COPY docs/package-files/* /usr/share/doc/stackato/
-
-ENTRYPOINT ["/catalog-service-manager/bin/catalog-service-manager"]

--- a/scripts/docker/release/generate-release-base-image.sh
+++ b/scripts/docker/release/generate-release-base-image.sh
@@ -28,7 +28,12 @@ then
 fi
 
 printf "${OK_GREEN_COLOR}==> Building ${SIDECAR_BASE_IMAGE_NAME}:${SIDECAR_BASE_IMAGE_TAG} image ..  ${NO_COLOR}\n"
-docker build -t ${SIDECAR_BASE_IMAGE_NAME}:${SIDECAR_BASE_IMAGE_TAG} --rm -f scripts/docker/release/Dockerfile-release .
+docker build \
+	-t ${SIDECAR_BASE_IMAGE_NAME}:${SIDECAR_BASE_IMAGE_TAG} \
+	--rm \
+	${SIDECAR_PARENT_IMAGE:+--build-arg base_image=${SIDECAR_PARENT_IMAGE}} \
+	-f scripts/docker/release/Dockerfile-release \
+	.
 
 echo ""
 echo ""


### PR DESCRIPTION
This
- makes the base image for all the sidecar things configurable
- defaults to openSUSE (but can be overridden to be SLE or whatever else has zypper)
- uses the minimal base image (instead of the build base) for the setup containers