### PR TITLE
Small fixes for concourse

### DIFF
--- a/scripts/build_version.sh
+++ b/scripts/build_version.sh
@@ -28,8 +28,8 @@ build_time=$(date -u +%Y%m%d%H%M%S)
 if [ -n "${CONCOURSEBUILD}" ]; then
   # concourse build number
   if [ "${BRANCH}" = "master" ]; then
-    export APP_VERSION=$(git describe --tags --long)
-    export APP_VERSION_TAG=$(git describe --tags --long)
+    export APP_VERSION="${VERSION:-$(git describe --tags --long)}"
+    export APP_VERSION_TAG="${VERSION:-$(git describe --tags --long)}"
     export APP_LATEST_BRANCH_TAG="latest"
   else
     export APP_VERSION="${VERSION}+${BRANCH}.${build_commit_hash}.${build_time}"

--- a/scripts/create_helm_charts_pr.sh
+++ b/scripts/create_helm_charts_pr.sh
@@ -32,9 +32,13 @@ pushd "${TMP_WORKDIR}"
 
 # Get the "hub" cli
 # https://hub.github.com/hub.1.html
-curl -L https://github.com/github/hub/releases/download/v2.3.0-pre10/hub-linux-amd64-2.3.0-pre10.tgz | tar xvz --wildcards --strip-components=2 '*/bin/hub'
-HUB="${PWD}/hub"
-chmod +x "${HUB}"
+if type -p hub ; then
+  HUB="$(type -p hub)"
+else
+  wget -O - https://github.com/github/hub/releases/download/v2.3.0-pre10/hub-linux-amd64-2.3.0-pre10.tgz | tar xvz --wildcards --strip-components=2 '*/bin/hub'
+  HUB="${PWD}/hub"
+  chmod +x "${HUB}"
+fi
 
 # Clone the kubernetes-charts-suse-com github repo
 "${HUB}" clone "git@github.com:${GITHUB_ORGANIZATION}/kubernetes-charts-suse-com.git"

--- a/scripts/docker/Dockerfile-build
+++ b/scripts/docker/Dockerfile-build
@@ -36,6 +36,10 @@ RUN unzip cf-plugin-usb.zip
 RUN mv cf-plugin-usb /out
 RUN chmod +x /out/cf-plugin-usb
 
+# "hub" CLI, https://hub.github.com/hub.1.html
+# Used to create PRs for helm chart distribution
+RUN wget -O - https://github.com/github/hub/releases/download/v2.3.0-pre10/hub-linux-amd64-2.3.0-pre10.tgz | tar xvz -C /usr/local/bin --wildcards --strip-components=2 '*/bin/hub'
+
 COPY . /go/src/github.com/SUSE/cf-usb-sidecar
 
 WORKDIR /go/src/github.com/SUSE/cf-usb-sidecar


### PR DESCRIPTION
Two small changes:
- Don't require `git` if the version is already supplied
- Put `hub` (the GitHub CLI) into the docker image, and use it if available, so that we don't need `curl` (and save a tiny bit of time).