### PR TITLE
Remove the tag which forces a full description, so that we get a shorter description when on a tagged version.

### DIFF
--- a/scripts/build_version.sh
+++ b/scripts/build_version.sh
@@ -9,7 +9,7 @@ set -o errexit -o nounset
 env_var_to_echo=$1
 
 git fetch --tags
-export APP_VERSION_TAG=$(git describe --tags --long)
+export APP_VERSION_TAG=$(git describe --tags)
 
 set +o errexit +o nounset +o xtrace
 


### PR DESCRIPTION
Ref: https://trello.com/c/u18ks0c3/632-2-sidecars-switch-tagging-of-current-builds