### PR TITLE
postgres: Add PGDATABASE configuration

### DIFF
--- a/csm-extensions/services/dev-postgres/chart/README.md
+++ b/csm-extensions/services/dev-postgres/chart/README.md
@@ -2,18 +2,19 @@
 
 This chart has the following set of parameters:
 
-|Name                       |Example        |Description                                           |
-|---                        |---            |---                                                   |
-|CF_ADMIN_PASSWORD          |hunter2        |SCF cluster admin password                            |
-|CF_ADMIN_USER              |admin          |SCF cluster admin user                                |
-|CF_CA_CERT                 |----- BEGIN... |The SCF CA cert                                       |
-|CF_DOMAIN                  |cf-dev.io      |The SCF base domain                                   |
-|SERVICE_LOCATION           |http://...     |URL to Kubernetes service `cf-usb-sidecar-postgresql` |
-|SERVICE_POSTGRESQL_HOST    |pg-staging     |The host of the postgres database to use              |
-|SERVICE_POSTGRESQL_PORT    |5432           |The port the postgres server listens on               |
-|SERVICE_POSTGRESQL_SSLMODE |disable        |Connection to postgres server, one of `disable`, `require`, `verify-ca`, `verify-full`. |
-|SERVICE_POSTGRESQL_USER    |root           |User to access the postgres database                  |
-|SERVICE_POSTGRESQL_PASS    |hunter2        |Credentials for the user above                        |
-|SERVICE_TYPE               |postgres       |The name used to register the sidecar with SCF        |
-|SIDECAR_LOG_LEVEL          |debug          |Logging level; more verbose than `info` is not recommended |
-|UAA_CA_CERT                |----- BEGIN... |The UAA CA certificate                                |
+|Name              |Example        |Description
+|---               |---            |---
+|CF_ADMIN_PASSWORD |hunter2        |SCF cluster admin password
+|CF_ADMIN_USER     |admin          |SCF cluster admin user name
+|CF_CA_CERT        |----- BEGIN... |The SCF CA cert
+|CF_DOMAIN         |cf-dev.io      |The SCF base domain
+|SERVICE_LOCATION  |http://...     |URL to Kubernetes service `cf-usb-sidecar-postgresql`
+|PGHOST            |pg-staging     |The host of the postgres database to use
+|PGPORT            |5432           |The port the postgres server listens on
+|PGSSLMODE         |disable        |Connection to postgres server, one of `disable`, `require`, `verify-ca`, `verify-full`
+|PGUSER            |root           |User to access the postgres database
+|PGPASSWORD        |hunter2        |Credentials for the user above
+|PGDATABASE        |postgres       |Name of database to connect to (optional)
+|SERVICE_TYPE      |postgres       |The name used to register the sidecar with SCF
+|SIDECAR_LOG_LEVEL |debug          |Logging level; more verbose than `info` is not recommended
+|UAA_CA_CERT       |----- BEGIN... |The UAA CA certificate

--- a/csm-extensions/services/dev-postgres/chart/other/setup.yaml
+++ b/csm-extensions/services/dev-postgres/chart/other/setup.yaml
@@ -18,20 +18,20 @@ spec:
               key: "cf-admin-password"
               name: "cf-usb-sidecar-postgres-secret"
         - name: "CF_ADMIN_USER"
-          value: {{ required "CF_ADMIN_USER configuration missing" .Values.env.CF_ADMIN_USER | quote }}
+          value: {{ template "getvar" (dict "ctx" . "names" (list "CF_ADMIN_USER")) }}
         - name: "CF_CA_CERT"
           valueFrom:
             secretKeyRef:
               key: "cf-ca-cert"
               name: "cf-usb-sidecar-postgres-secret"
         - name: "CF_DOMAIN"
-          value: {{ required "CF_DOMAIN configuration missing" .Values.env.CF_DOMAIN | quote }}
+          value: {{ template "getvar" (dict "ctx" . "names" (list "CF_DOMAIN")) }}
         - name: "KUBERNETES_NAMESPACE"
           valueFrom:
             fieldRef:
               fieldPath: "metadata.namespace"
         - name: "SERVICE_LOCATION"
-          value: {{ required "SERVICE_LOCATION configuration missing" .Values.env.SERVICE_LOCATION | quote }}
+          value: {{ template "getvar" (dict "ctx" . "names" (list "SERVICE_LOCATION") "default" (printf "http://cf-usb-sidecar-postgres.%s:8081" .Release.Namespace)) }}
         - name: "SERVICE_TYPE"
           value: {{ .Values.env.SERVICE_TYPE | quote }}
         - name: "SIDECAR_API_KEY"

--- a/csm-extensions/services/dev-postgres/chart/templates/_helpers.tpl
+++ b/csm-extensions/services/dev-postgres/chart/templates/_helpers.tpl
@@ -1,0 +1,37 @@
+{{/* This files contains templates for the variable name transition */}}
+
+{{/* Get a variable, with an error message if it's missing. Arguments are passed as a list. */}}
+{{- define "getvar"}}{{/* (dict "ctx" . "names" (list "A" "B") "quote" true "b64" false) */}}
+    {{- with $v := . -}}
+        {{- if hasKey $v "quote" | not -}}
+            {{- with set $v "quote" true -}}
+                {{/* We don't actually need the result of the "set", but need to discard it */}}
+            {{- end -}}
+        {{- end -}}
+        {{- if hasKey $v "b64" | not -}}
+            {{- with set $v "b64" false -}}
+                {{/* We don't actually need the result of the "set", but need to discard it */}}
+            {{- end -}}
+        {{- end -}}
+        {{- range $name := index $v "names" | reverse -}}
+            {{- if hasKey (index $v "ctx" "Values" "env") $name -}}
+                {{- with set $v "result" (index $v "ctx" "Values" "env" $name) -}}
+                    {{/* We don't actually need the result of the "set", but need to discard it */}}
+                {{- end -}}
+            {{- end -}}
+        {{- end -}}
+        {{- if (index $v "quote") -}}
+            {{- if (index $v "b64") -}}
+                {{- required (printf "env.%s configuration missing" (index $v "names" 0) ) (index $v "result") | b64enc | quote -}}
+            {{- else -}}
+                {{- required (printf "env.%s configuration missing" (index $v "names" 0) ) (index $v "result") | quote -}}
+            {{- end -}}
+        {{- else -}}
+            {{- if (index $v "b64") -}}
+                {{- required (printf "env.%s configuration missing" (index $v "names" 0) ) (index $v "result") | b64enc -}}
+            {{- else -}}
+                {{- required (printf "env.%s configuration missing" (index $v "names" 0) ) (index $v "result") -}}
+            {{- end -}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}

--- a/csm-extensions/services/dev-postgres/chart/templates/_helpers.tpl
+++ b/csm-extensions/services/dev-postgres/chart/templates/_helpers.tpl
@@ -1,24 +1,30 @@
 {{/* This files contains templates for the variable name transition */}}
 
-{{/* Get a variable, with an error message if it's missing. Arguments are passed as a list. */}}
-{{- define "getvar"}}{{/* (dict "ctx" . "names" (list "A" "B") "quote" true "b64" false) */}}
+{{/* Set a default value in a dict */}}
+{{- define "_setdefault" -}}{{/* (list <dict> <name> <default>) */}}
     {{- with $v := . -}}
-        {{- if hasKey $v "quote" | not -}}
-            {{- with set $v "quote" true -}}
+        {{- if hasKey (index $v 0) (index $v 1) | not -}}
+            {{- with set (index $v 0) (index $v 1) (index $v 2) -}}
                 {{/* We don't actually need the result of the "set", but need to discard it */}}
             {{- end -}}
         {{- end -}}
-        {{- if hasKey $v "b64" | not -}}
-            {{- with set $v "b64" false -}}
-                {{/* We don't actually need the result of the "set", but need to discard it */}}
-            {{- end -}}
-        {{- end -}}
-        {{- range $name := index $v "names" | reverse -}}
+    {{- end -}}
+{{- end -}}
+
+{{/* Get a variable, with an error message if it's missing. Arguments are passed as a list. */}}
+{{- define "getvar" }}{{/* (dict "ctx" . "names" (list "A" "B") "quote" true "b64" false) */}}
+    {{- with $v := . -}}
+        {{- template "_setdefault" (list $v "quote" true) -}}
+        {{- template "_setdefault" (list $v "b64" false) -}}
+        {{- range $name := index $v "names" -}}
             {{- if hasKey (index $v "ctx" "Values" "env") $name -}}
-                {{- with set $v "result" (index $v "ctx" "Values" "env" $name) -}}
-                    {{/* We don't actually need the result of the "set", but need to discard it */}}
+                {{- if typeIs "<nil>" (index $v "ctx" "Values" "env" $name) | not -}}
+                    {{- template "_setdefault" (list $v "result" (index $v "ctx" "Values" "env" $name)) -}}
                 {{- end -}}
             {{- end -}}
+        {{- end -}}
+        {{- if hasKey $v "default" -}}
+            {{- template "_setdefault" (list $v "result" (index $v "default")) -}}
         {{- end -}}
         {{- if (index $v "quote") -}}
             {{- if (index $v "b64") -}}

--- a/csm-extensions/services/dev-postgres/chart/templates/db.yaml
+++ b/csm-extensions/services/dev-postgres/chart/templates/db.yaml
@@ -2,7 +2,7 @@
 # The postgres role contains a plain postgres server
 # This is only deployed if this  helm chart was deployed with a host of "AUTO"
 
-{{ if eq ( .Values.env.SERVICE_POSTGRESQL_HOST | quote ) ( "AUTO" | quote ) }}
+{{ if eq ( .Values.env.PGHOST | quote ) ( "AUTO" | quote ) }}
 apiVersion: apps/v1beta1
 kind: StatefulSet
 metadata:
@@ -26,7 +26,7 @@ spec:
               key: service-postgres-pass
               name: cf-usb-sidecar-postgres-secret
         - name: POSTGRES_USER
-          value: {{ required "SERVICE_POSTGRESQL_USER configuration missing" .Values.env.SERVICE_POSTGRESQL_USER | quote }}
+          value: {{ template "getvar" (dict "ctx" . "names" (list "PGUSER" "SERVICE_POSTGRESQL_USER")) }}
         image: "{{ .Values.kube.registry.hostname }}/{{ .Values.kube.organization }}/cf-usb-sidecar-postgres-db:latest"
         readinessProbe:
           initialDelaySeconds: 10
@@ -67,7 +67,7 @@ items:
   spec:
     ports:
     - name: postgres
-      port: {{ required "SERVICE_POSTGRESQL_PORT configuration missing" .Values.env.SERVICE_POSTGRESQL_PORT }}
+      port: {{ template "getvar" (dict "ctx" . "names" (list "PGPORT" "SERVICE_POSTGRESQL_PORT") "quote" false) }}
       protocol: TCP
       targetPort: postgres
     selector:

--- a/csm-extensions/services/dev-postgres/chart/templates/secrets.yaml
+++ b/csm-extensions/services/dev-postgres/chart/templates/secrets.yaml
@@ -2,7 +2,7 @@
 apiVersion: "v1"
 data:
   # The password for access to the configured postgres database.
-  service-postgres-pass: {{ required "SERVICE_POSTGRESQL_PASS configuration missing" .Values.env.SERVICE_POSTGRESQL_PASS | b64enc | quote }}
+  service-postgres-pass: {{ template "getvar" (dict "ctx" . "names" (list "PGPASSWORD" "SERVICE_POSTGRESQL_PASS") "b64" true) }}
 
   # The token for sidecar access by the cf-usb role in SCF.
   sidecar-api-key: {{ randAlphaNum 32 | b64enc | quote }}
@@ -10,13 +10,13 @@ data:
   # The PEM-encoded SCF CA certificate used to sign the TLS
   # certificate required by the cf client in the setup task to secure
   # the communication with the api endpoint.
-  cf-ca-cert: {{ required "CF_CA_CERT configuration missing" .Values.env.CF_CA_CERT | b64enc | quote }}
+  cf-ca-cert: {{ template "getvar" (dict "ctx" . "names" (list "CF_CA_CERT") "b64" true) }}
 
   # The PEM-encoded UAA CA certificate
-  uaa-ca-cert: {{ required "UAA_CA_CERT configuration missing" .Values.env.UAA_CA_CERT | b64enc | quote }}
+  uaa-ca-cert: {{ template "getvar" (dict "ctx" . "names" (list "UAA_CA_CERT") "b64" true) }}
 
   # Cluster password
-  cf-admin-password: {{ required "CF_ADMIN_PASSWORD configuration missing" .Values.env.CF_ADMIN_PASSWORD | b64enc | quote }}
+  cf-admin-password: {{ template "getvar" (dict "ctx" . "names" (list "CF_ADMIN_PASSWORD") "b64" true) }}
 
 kind: "Secret"
 metadata:

--- a/csm-extensions/services/dev-postgres/chart/templates/sidecar.yaml
+++ b/csm-extensions/services/dev-postgres/chart/templates/sidecar.yaml
@@ -24,20 +24,26 @@ spec:
             fieldRef:
               fieldPath: "metadata.namespace"
         - name: "SERVICE_POSTGRES_HOST"
-          value: {{ if eq ( .Values.env.SERVICE_POSTGRESQL_HOST | quote ) ( "AUTO" | quote ) }} postgres.{{.Release.Namespace}} {{ else }} {{ required "SERVICE_POSTGRESQL_HOST configuration missing; use AUTO to deploy one" .Values.env.SERVICE_POSTGRESQL_HOST | quote }} {{ end }}
+          value:  {{ if eq ( .Values.env.PGHOST | quote ) ( "AUTO" | quote ) -}}
+                    postgres.{{.Release.Namespace}}
+                  {{- else -}}
+                    {{ template "getvar" (dict "ctx" . "names" (list "PGHOST" "SERVICE_POSTGRESQL_HOST")) }}
+                  {{- end }}
         - name: "SERVICE_POSTGRES_PORT"
-          value: {{ required "SERVICE_POSTGRESQL_PORT configuration missing" .Values.env.SERVICE_POSTGRESQL_PORT | quote }}
+          value: {{ template "getvar" (dict "ctx" . "names" (list "PGPORT" "SERVICE_POSTGRESQL_PORT")) }}
         - name: "SERVICE_POSTGRES_SSLMODE"
-          value: {{ .Values.env.SERVICE_POSTGRESQL_SSLMODE | default "prefer" | quote }}
+          value: {{ template "getvar" (dict "ctx" . "names" (list "PGSSLMODE" "SERVICE_POSTGRESQL_SSLMODE")) }}
         - name: "SERVICE_POSTGRES_USER"
-          value: {{ required "SERVICE_POSTGRESQL_USER configuration missing" .Values.env.SERVICE_POSTGRESQL_USER | quote }}
+          value: {{ template "getvar" (dict "ctx" . "names" (list "PGUSER" "SERVICE_POSTGRESQL_USER")) }}
+        - name: "PGDATABASE"
+          value: {{ template "getvar" (dict "ctx" . "names" (list "PGDATABASE")) }}
         - name: "SERVICE_POSTGRES_PASSWORD"
           valueFrom:
             secretKeyRef:
               key: "service-postgres-pass"
               name: "cf-usb-sidecar-postgres-secret"
         - name: SIDECAR_LOG_LEVEL
-          value: {{ .Values.env.SIDECAR_LOG_LEVEL | default "info" | quote }}
+          value: {{ template "getvar" (dict "ctx" . "names" (list "SIDECAR_LOG_LEVEL")) }}
         - name: "SIDECAR_API_KEY"
           valueFrom:
             secretKeyRef:

--- a/csm-extensions/services/dev-postgres/chart/values.yaml
+++ b/csm-extensions/services/dev-postgres/chart/values.yaml
@@ -5,11 +5,12 @@ env:
   CF_CA_CERT: ~
   CF_DOMAIN: ~
   SERVICE_LOCATION: ~
-  SERVICE_POSTGRESQL_HOST: ~
-  SERVICE_POSTGRESQL_PASS: cf-usb-sidecar-postgres-admin-password
-  SERVICE_POSTGRESQL_PORT: 5432
-  SERVICE_POSTGRESQL_SSLMODE: require
-  SERVICE_POSTGRESQL_USER: postgres
+  SERVICE_POSTGRESQL_HOST: ~                                       # The preferred name for this is "PGHOST"
+  SERVICE_POSTGRESQL_PASS: cf-usb-sidecar-postgres-admin-password  # The preferred name for this is "PGPASSWORD"
+  SERVICE_POSTGRESQL_PORT: 5432                                    # The preferred name for this is "PGPORT"
+  SERVICE_POSTGRESQL_SSLMODE: require                              # The preferred name for this is "PGSSLMODE"
+  SERVICE_POSTGRESQL_USER: postgres                                # The preferred name for this is "PGUSER"
+  PGDATABASE: postgres
   SERVICE_TYPE: postgres
   SIDECAR_LOG_LEVEL: info
   UAA_CA_CERT: ~

--- a/scripts/dev-extensions/build-docker-image.sh
+++ b/scripts/dev-extensions/build-docker-image.sh
@@ -5,3 +5,6 @@ docker build -t ${SIDECAR_EXTENSION_IMAGE_NAME}:${SIDECAR_EXTENSION_IMAGE_TAG} -
 if test -f Dockerfile-setup ; then
     docker build -t ${SIDECAR_SETUP_IMAGE_NAME}:${SIDECAR_SETUP_IMAGE_TAG}     --rm ${SIDECAR_PARENT_IMAGE:+--build-arg base_image=${SIDECAR_PARENT_IMAGE}} -f Dockerfile-setup .
 fi
+if test -f Dockerfile-db ; then
+    docker build -t ${SIDECAR_EXTENSION_SVC_IMAGE_NAME}:${SIDECAR_EXTENSION_SVC_IMAGE_TAG}     --rm ${SIDECAR_PARENT_IMAGE:+--build-arg base_image=${SIDECAR_PARENT_IMAGE}} -f Dockerfile-db .
+fi


### PR DESCRIPTION
Also support using postgres-standard names for the variables rather than the odd custom ones.  This is all shimmed back in the helm chart, and no changes to the actual broker are done.

Also adds a helm template helper for the repeated variable getting and error messaging.