### PR TITLE
Various build fixes

### DIFF
--- a/csm-extensions/services/dev-mysql/chart/templates/sidecar.yaml
+++ b/csm-extensions/services/dev-mysql/chart/templates/sidecar.yaml
@@ -16,7 +16,7 @@ spec:
       name: "cf-usb-sidecar-mysql"
     spec:
       containers:
-      - image: "{{ .Values.kube.registry.hostname }}/{{ .Values.kube.organization }}/cf-usb-sidecar-mysql:1.0.1"
+      - image: "{{ .Values.kube.registry.hostname }}/{{ .Values.kube.organization }}/cf-usb-sidecar-mysql:latest"
         name: "cf-usb-sidecar-mysql"
         env:
         - name: "KUBERNETES_NAMESPACE"

--- a/scripts/docker/Dockerfile-build
+++ b/scripts/docker/Dockerfile-build
@@ -1,6 +1,8 @@
-ARG base_image=opensuse:latest
+ARG base_image=opensuse/leap:latest
 
 FROM ${base_image}
+
+ARG hub_version=2.3.0-pre10
 
 # If we're on the SLE container, delete the magic helper for SCC registration
 # It just slows down zypper
@@ -12,22 +14,23 @@ ARG repo_cloud_tools=obs://Cloud:Tools
 ARG repo_devel_languages_go=obs://devel:languages:go
 ARG repo_extra
 # Useless command to _use_ the args, which somehow makes things work. Not sure why.
-RUN true "${repo_cloud_tools} ${repo_devel_languages_go} ${repo_extra}"
-RUN zypper --non-interactive addrepo --check --gpgcheck "${repo_cloud_tools}" "Cloud:Tools"
-RUN zypper --non-interactive addrepo --check --gpgcheck "${repo_devel_languages_go}" "devel:languages:go"
-RUN if test -n "${repo_extra}" ; then \
-    zypper --non-interactive addrepo --check --gpgcheck "${repo_extra}" "extra" ; \
-    fi
-RUN zypper --non-interactive --gpg-auto-import-keys refresh
-RUN zypper --non-interactive install \
-    cf-cli \
-    git \
-    go \
-    make \
-    tar \
-    unzip \
-    wget \
-    ${NULL}
+RUN set -o errexit -o nounset -o xtrace \
+    ; zypper --non-interactive addrepo --check --gpgcheck "${repo_cloud_tools}" "Cloud:Tools" \
+    ; zypper --non-interactive addrepo --check --gpgcheck "${repo_devel_languages_go}" "devel:languages:go" \
+    ; if test -n "${repo_extra}" ; then \
+        zypper --non-interactive addrepo --check --gpgcheck "${repo_extra}" "extra" \
+    ; fi \
+    ; zypper --non-interactive --gpg-auto-import-keys refresh \
+    ; zypper --non-interactive install \
+        cf-cli \
+        git \
+        gzip \
+        go \
+        make \
+        tar \
+        unzip \
+        wget \
+    ; true
 
 RUN mkdir /out
 
@@ -38,7 +41,7 @@ RUN chmod +x /out/cf-usb-plugin
 
 # "hub" CLI, https://hub.github.com/hub.1.html
 # Used to create PRs for helm chart distribution
-RUN wget -O - https://github.com/github/hub/releases/download/v2.3.0-pre10/hub-linux-amd64-2.3.0-pre10.tgz | tar xvz -C /usr/local/bin --wildcards --strip-components=2 '*/bin/hub'
+RUN wget -O - https://github.com/github/hub/releases/download/v${hub_version}/hub-linux-amd64-${hub_version}.tgz | tar xvz -C /usr/local/bin --wildcards --strip-components=2 '*/bin/hub'
 
 COPY . /go/src/github.com/SUSE/cf-usb-sidecar
 


### PR DESCRIPTION
We haven't touched this repo in a while, this is just a PR to fix some build issues:

- Use the `opensuse/leap` docker image, instead of the (no-longer-existing) `library/opensuse` one.
- Partially revert 6cec86b56d2838bc3973cb921c44ff63e4eeb9f4 as the CI pipeline (via [`scripts/helm.sh`](https://github.com/SUSE/cf-usb-sidecar/blob/897e67ee58f4f4bc29c88bd69bb6a40698c2b37c/scripts/helm.sh#L29)) will substitute the correct image tag on publish.
- Simplify the code to find the CA certificate directory in MySQL (copying the code from Postgres over), as it was failing to identify recent openSUSE (because `/etc/SuSE-release` was deprecated).